### PR TITLE
fix: getPrice also filters with price equals -1

### DIFF
--- a/components/utils/renderHelpers.js
+++ b/components/utils/renderHelpers.js
@@ -171,6 +171,7 @@ export function getPrice(price, currency) {
   if (
     price === "0" ||
     price === "-1" ||
+    price === -1 ||
     price === undefined ||
     price.toString().toLowerCase() === "none"
   ) {


### PR DESCRIPTION
We were checking for "-1" but not -1 (as number). Added that check to show consultar 